### PR TITLE
Do not merge, PR to demo why we need src folder

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,8 +90,3 @@ install_requires =
 
 [options.packages.find]
 where = f4enix
-
-[options.package_data]
-# Include any *.txt files found in the resources package (but not in its
-# subpackages):
-* = *.txt, *.xlsx


### PR DESCRIPTION
# Description

To demonstrate why a ```src``` folder layout would be helpful I have removed files txt and excel from package files in the setup.cfg.

I notice the CI does a ```pip install .``` with the objective of testing the package

I think as we are in the repository root folder with a folder called ```f4enix``` in that same folder then when we run ```import f4enix``` we import that folder, not the package

So we are not testing what we think we are testing. We are testing the folder contents not the package

Moving to a ```src/f4enix``` layout would fix this