### PR TITLE
Improve material comments

### DIFF
--- a/docs/source/examples/input/jupyters/e_lite.ipynb
+++ b/docs/source/examples/input/jupyters/e_lite.ipynb
@@ -9,6 +9,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extract an E-lite sector"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -112,6 +119,98 @@
    "source": [
     "To actually use the class Elite_Input you will need the Excel spreadsheet with the block structure of E-lite and the patch to fix the lost particles arising in the model of the sector after the extraction. You can require them by contacting the developers."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Format materials for E-lite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "E-lite has a specific formatting for materials. Generally in F4Enix, for each zaid, a dollar command is added reporting:\n",
+    "\n",
+    "* The weight percentage of the element it belongs to in the submaterial\n",
+    "* The atom fraction of the zaid in the element (abundance)\n",
+    "\n",
+    "In addition to this, the E-lite standard requires the atom fraction of the single zaids to actually represent the atomic density of such zaid in the material (given a certain nominal density of the material). This will cause the fractions to be not normalized.\n",
+    "\n",
+    "There is a specific function in F4Enix to port all materials in an MCNP input (or a single material) to such standard.\n",
+    "\n",
+    "First, let's load an example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C \n",
+      "M1\n",
+      "       1001.31c        1.999710E+0     $ H-1    WEIGHT(%) 11.19 AB(%) 99.986\n",
+      "       1002.31c        2.900000E-4     $ H-2    WEIGHT(%) 11.19 AB(%) 0.0145\n",
+      "       8016.31c        9.975700E-1     $ O-16   WEIGHT(%) 88.81 AB(%) 99.757\n",
+      "       8017.31c        3.835000E-4     $ O-17   WEIGHT(%) 88.81 AB(%) 0.03835\n",
+      "       8018.31c        2.045000E-3     $ O-18   WEIGHT(%) 88.81 AB(%) 0.2045\n"
+     ]
+    }
+   ],
+   "source": [
+    "from f4enix.input.materials import Material, MatCardsList\n",
+    "from f4enix.input.libmanager import LibManager\n",
+    "\n",
+    "lm = LibManager()\n",
+    "material = Material.from_zaids([('H', 2), ('O', 1)], lm, '31c')\n",
+    "mat_library = MatCardsList([material])\n",
+    "print(mat_library.to_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then convert it to the E-lite standard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C \n",
+      "M1\n",
+      "       1001.31c        6.550811E-2     $ H-1    WEIGHT(%) 11.19 AB(%) 99.986\n",
+      "       1002.31c        9.500054E-6     $ H-2    WEIGHT(%) 11.19 AB(%) 0.0145\n",
+      "       8016.31c        3.267920E-2     $ O-16   WEIGHT(%) 88.81 AB(%) 99.757\n",
+      "       8017.31c        1.256300E-5     $ O-17   WEIGHT(%) 88.81 AB(%) 0.03835\n",
+      "       8018.31c        6.699176E-5     $ O-18   WEIGHT(%) 88.81 AB(%) 0.2045\n"
+     ]
+    }
+   ],
+   "source": [
+    "density = 0.98 # g/cm3\n",
+    "\n",
+    "mat_library.fractions_to_atom_densities(lm, density)\n",
+    "print(mat_library.to_text())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/MCNPinput_test.py
+++ b/tests/MCNPinput_test.py
@@ -265,7 +265,10 @@ class TestInput:
         assert True
 
         # let's check also that abundances info is correctly added
-        assert "$ H-1    AB(%) 99.988" in newinput.materials.materials[0].to_text()
+        assert (
+            "$ H-1    WEIGHT(%) 100.0 AB(%) 99.988"
+            in newinput.materials.materials[0].to_text()
+        )
 
     def test_get_cells_by_id(self):
         cards = self.testInput.get_cells_by_id([1, 2])

--- a/tests/materials_test.py
+++ b/tests/materials_test.py
@@ -521,6 +521,25 @@ class TestMatCardList:
 
         compare_without_dollar_comments(text_B, newmat.to_text())
 
+    def test_fractions_to_atom_density(self):
+        matcard = deepcopy(inp3_matcard2)
+        density = 2
+
+        submats = matcard["m1"].switch_fraction("mass", LIBMAN, inplace=False)
+        newmat = Material(None, None, "", submaterials=submats)
+        submats = newmat.switch_fraction("atom", LIBMAN, inplace=False)
+        fraction = submats[0].zaidList[0].fraction
+
+        tad = matcard["m1"].get_tad(density, LIBMAN)
+
+        matcard.fractions_to_atom_densities(LIBMAN, density)
+
+        assert (
+            pytest.approx(matcard["m1"].submaterials[0].zaidList[0].fraction)
+            == fraction * tad
+        )
+        assert matcard["m1"].submaterials[0].zaidList[1].fraction > 0
+
 
 def compare_without_dollar_comments(text_A: str, text_B: str):
     # strip all dollars


### PR DESCRIPTION
# Description

This PR has two objectives:
 * Add the elemental weight percentage (in the submaterial) to the dollar comment of each zaid
 * Add a method to standardize the materials according to E-lite standard (i.e., atom fractions need to be not normalized and 
    instead represent the atom density of each zaid in the material given a nominal density

Fixes #130 

Below a screenshot from the documentation that illustrate the changes

![image](https://github.com/user-attachments/assets/7c271d2a-a676-48fc-9efc-34c4c734ef1d)


## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [x] This change requires a documentation update

# Testing

Suitable tests have been added to the CI suite

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] General testing 
    - [x] New and existing unit tests pass locally with my changes
    - [x] Coverage is >80%