### PR TITLE
Improve rssa cyl plots

### DIFF
--- a/src/f4enix/output/rssa/rssa.py
+++ b/src/f4enix/output/rssa/rssa.py
@@ -1,6 +1,4 @@
 """This module is related to the parsing of D1S-UNED meshinfo files."""
-
-from collections.abc import Sequence
 from pathlib import Path
 
 import polars as pl
@@ -139,9 +137,6 @@ class RSSA:
     def histories(self) -> pl.Series:
         """Returns the history numbers of the tracks."""
         return self.tracks["a"]
-
-    def get_energy_spectra(self, energy_bins: Sequence[float]) -> pl.DataFrame:
-        raise NotImplementedError()
 
     def plot_plane(self) -> RSSAPlot:
         """Returns an instance of RSSAPlot to plot data assuming an XY plane."""

--- a/src/f4enix/output/rssa/rssa_plotting.py
+++ b/src/f4enix/output/rssa/rssa_plotting.py
@@ -78,12 +78,12 @@ class PlottingFunctions(ABC):
         """
         It adds a new column to the tracks DataFrame called 'perimeter_pos' that takes
         the X and Y coordinates and calculates the position as a perimeter coordinate.
-        The perimeter position is calculated as theta * r, where theta is the angle in
+        The perimeter position is calculated as -theta * r, where theta is the angle in
         radians and r is the radius of each track.
         """
         radius = (pl.col("x").pow(2) + pl.col("y").pow(2)).sqrt()
         thetas = pl.arctan2(pl.col("y"), pl.col("x"))
-        perimeter_pos = (thetas * radius).alias("perimeter_pos")
+        perimeter_pos = (thetas * radius * -1).alias("perimeter_pos")
         self.tracks = self.tracks.with_columns(perimeter_pos)
 
     @abstractmethod

--- a/src/f4enix/output/rssa/rssa_plotting.py
+++ b/src/f4enix/output/rssa/rssa_plotting.py
@@ -78,12 +78,17 @@ class PlottingFunctions(ABC):
         """
         It adds a new column to the tracks DataFrame called 'perimeter_pos' that takes
         the X and Y coordinates and calculates the position as a perimeter coordinate.
-        The perimeter position is calculated as -theta * r, where theta is the angle in
+        The perimeter position is calculated as theta * r, where theta is the angle in
         radians and r is the radius of each track.
+
+        The theta is calculated using the arctan2 function, which gives the angle
+        between the positive X-axis and the point (x, y). In that calculation, the X
+        coordinate is multiplied by -1 to "flip" the plot, this way it looks as a
+        cylinder observed from the inside.
         """
         radius = (pl.col("x").pow(2) + pl.col("y").pow(2)).sqrt()
-        thetas = pl.arctan2(pl.col("y"), pl.col("x"))
-        perimeter_pos = (thetas * radius * -1).alias("perimeter_pos")
+        thetas = pl.arctan2(pl.col("y"), -1 * pl.col("x"))
+        perimeter_pos = (thetas * radius).alias("perimeter_pos")
         self.tracks = self.tracks.with_columns(perimeter_pos)
 
     @abstractmethod


### PR DESCRIPTION
The cylindrical plotting of RSSA files used to show the theta lower values at the left of the plot, this is akin as looking at a cylinder from the outside. We are used to viusalizations where we study cylinders from the inside, this change makes confusions less likely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed a public API method for retrieving energy spectra from the RSSA interface.

* **Bug Fixes**
  * Fixed perimeter position/orientation in radial plotting so rendered cylindrical views appear correctly (angle flipped to simulate inside-facing perspective).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->