### PR TITLE
flag fix source extraction

### DIFF
--- a/src/f4enix/input/elite.py
+++ b/src/f4enix/input/elite.py
@@ -76,6 +76,7 @@ class Elite_Input(Input):
         outfile: os.PathLike = "sector",
         tol: float = 1e-5,
         check_Elite: bool = False,
+        fix_source: bool = True,
     ) -> None:
         """Writes a working input of a user-selected E-Lite sector.
 
@@ -124,6 +125,9 @@ class Elite_Input(Input):
         check_Elite : bool, optional
             Automatically checks if the envelope structure of the model is
             consistent with the one reported in the Excel, by default False
+        fix_source : bool, optional
+            If True, the source will be modified to be consistent with the
+            extracted sector(s), by default True
         """
         if not self.__initialized:
             self._initialize_elite(excel_file, check_Elite)
@@ -171,7 +175,8 @@ class Elite_Input(Input):
         #     if pattern.match(key):
         #         modified_data_cards.pop(key)
         # modify sdef
-        Elite_Input._set_sdef(sectors, modified_data_cards)
+        if fix_source:
+            Elite_Input._set_sdef(sectors, modified_data_cards)
         # set L0 as periodic and modify L1 planes
         Elite_Input._set_boundaries(
             Elite_Input._get_boundaries_angles(sectors),


### PR DESCRIPTION
# Description

Very minor introduction of a flag for sector extraction, to prevent failure in case non standard DT source is used in E-lite (RE electrons, Fi sourec in SRO)

## Type of change

Please select what type of change this is.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
    - [x] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve source-related entries when extracting sectors.
  * Source entries continue to be updated by default, with the option to disable this behavior when needed.
  * Updated method documentation to describe the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->