### PR TITLE
fix irrfile header template

### DIFF
--- a/src/f4enix/input/d1suned.py
+++ b/src/f4enix/input/d1suned.py
@@ -1119,14 +1119,14 @@ def _get_irradiation_header(
     irr_scenarios: list[IrradiationScenario], norm: float
 ) -> str:
     header = """
-# *******************************
-#     Irradiation Scenarios
-# *******************************    
+C *******************************
+C     Irradiation Scenarios
+C *******************************
 """
-    header += f"# norm: {norm}\n\n"
+    header += f"C norm: {norm}\n\n"
     for irr_scenario in irr_scenarios:
-        header += f"# Scenario: {irr_scenario.name}\n"
+        header += f"C Scenario: {irr_scenario.name}\n"
         for pulse in irr_scenario.pulses:
-            header += f"#   - {pulse}\n"
+            header += f"C   - {pulse}\n"
         header += "\n"
     return header


### PR DESCRIPTION
# Description

Quick fix as d1suned works with C comments, not #

## Type of change

Please select what type of change this is.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
    - [ ] Non-breaking change which adds functionality
    - [ ] Breaking change fix or feature that would cause existing functionality to not work as expected

## Other changes

- [ ] This change requires a documentation update

# Testing

Tried execution with d1suned 4.1.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] General testing 
    - [ ] New and existing unit tests pass locally with my changes
    - [ ] Coverage is >80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated D1S irradiation scenario headers to use the correct `C`-prefixed comment format.
  * Improved header readability with consistent banner spacing and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->